### PR TITLE
Fix cmp_hashrec for 64 bits

### DIFF
--- a/simhash/_simhash.c
+++ b/simhash/_simhash.c
@@ -128,8 +128,9 @@ struct hashrec {
 };
 
 static int cmp_hashrec(const void *a, const void *b) {
-    return ((const struct hashrec *) a)->hash -
+    PY_LONG_LONG result = ((const struct hashrec *) a)->hash -
         ((const struct hashrec *) b)->hash;
+    return (result > 0) - (result < 0);
 }
 
 static PyObject *similar_indices(PyObject *self, PyObject *args)


### PR DESCRIPTION
In 
```
static int cmp_hashrec(const void *a, const void *b) {
 return ((const struct hashrec *) a)->hash - ((const struct hashrec *) b)->hash;
```

result may not fit into `int` since `hash` is `PY_LONG_LONG`